### PR TITLE
correct spelling for session in bgp prefix

### DIFF
--- a/bgp/bgp_collector.go
+++ b/bgp/bgp_collector.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const prefix string = "junos_bgp_seesion_"
+const prefix string = "junos_bgp_session_"
 
 var (
 	upDesc               *prometheus.Desc


### PR DESCRIPTION
This corrects the spelling for prefix = "junos_bgp_session_" and therefore
changes all the bgp time series.

Signed-off-by: Magnus Frühling <magnus.fruehling@innovo-cloud.de>